### PR TITLE
added Many scan type. Added non-html escaped json marshal. flshed out…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .AppleDouble
 .LSOverride
 
+# misc. editors
+.vscode
+
 # Thumbnail files
 ._*
 

--- a/examples/go_sql/main.go
+++ b/examples/go_sql/main.go
@@ -34,6 +34,15 @@ type queryResp struct {
 
 func main() {
 
+	type x struct {
+		Name  string `json:"name"`
+		Loc   string `json:"location"`
+		Place string `json:"place"`
+	}
+	t := x{"mark", "baltimore", "home"}
+	u := sql2.StructToNamedArgs(t, "place")
+	fmt.Println(u)
+
 	// Connect the way you would usually
 	db, err := sql.Open("surrealdb", "ws://root:root@localhost:8000/?ns=test&db=test")
 	if err != nil {

--- a/examples/go_sql/main.go
+++ b/examples/go_sql/main.go
@@ -81,7 +81,19 @@ func main() {
 	}
 
 	// Read it back
-	rows, err := db.Query("SELECT id, name, ->posted as posted, ->posted->post AS posts FROM user:mark fetch posts, posted")
+	rows, err := db.Query(`
+	SELECT
+		id,
+		name,
+		->posted as posted,
+		->posted->post AS posts
+	FROM
+		user:mark
+	FETCH
+		posts, posted
+	
+		`)
+
 	if err != nil {
 		panic(err)
 	}

--- a/examples/go_sql/main.go
+++ b/examples/go_sql/main.go
@@ -88,7 +88,15 @@ func main() {
 		fmt.Println("row", resp)
 	}
 
-	// get records by named params
+	// get record using a query with a named param
+	resp := queryResp{}
+	err = db.QueryRow("SELECT id, name, ->posted as posted, ->posted->post AS posts FROM user where name = $crazy_param_name fetch posts, posted", sql.Named("crazy_param_name", "mark")).Scan(&resp.ID, &resp.Name, &resp.Posted, &resp.Posts)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("named param response:", resp)
+
+	// get records by named params using a prepared statement
 	stmt, err := db.Prepare("SELECT id, name, ->posted as posted, ->posted->post AS posts FROM user where name = $user_name fetch posts, posted")
 	if err != nil {
 		panic(err)

--- a/examples/go_sql/main.go
+++ b/examples/go_sql/main.go
@@ -88,6 +88,22 @@ func main() {
 		fmt.Println("row", resp)
 	}
 
+	// get records by named params
+	stmt, err := db.Prepare("SELECT id, name, ->posted as posted, ->posted->post AS posts FROM user where name = $user_name fetch posts, posted")
+	if err != nil {
+		panic(err)
+	}
+	rows, err = stmt.Query(sql.Named("user_name", "mark"))
+	for rows.Next() {
+		resp := queryResp{}
+		err := rows.Scan(&resp.ID, &resp.Name, &resp.Posted, &resp.Posts)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println("row", resp)
+	}
+
 	// Cleanup
 	err = db.Close()
 	if err != nil {

--- a/examples/go_sql/main.go
+++ b/examples/go_sql/main.go
@@ -3,17 +3,49 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"time"
+
 	sql2 "github.com/surrealdb/surrealdb.go/sql"
 
 	_ "github.com/surrealdb/surrealdb.go/sql"
 )
 
+type user struct {
+	sql2.BaseEntity
+	Name string `json:"name"`
+	Age  int    `json:"age"`
+}
+type post struct {
+	sql2.BaseEntity
+	Title string `json:"title"`
+	Slug  string `json:"slug"`
+}
+
+type posted struct {
+	sql2.BaseRelationship
+	When time.Time `json:"when"`
+}
+
+type queryResp struct {
+	user
+	Posts  sql2.Many[post]   `json:"posts"`
+	Posted sql2.Many[posted] `json:"posted"`
+}
+
 func main() {
+
 	// Connect the way you would usually
-	db, err := sql.Open("surrealdb", "ws://root:root@localhost:9091/?ns=my-namespace&db=dbname")
+	db, err := sql.Open("surrealdb", "ws://root:root@localhost:8000/?ns=test&db=test")
 	if err != nil {
 		panic(err)
 	}
+
+	// clear tables
+	func() {
+		db.Exec("DELETE user")
+		db.Exec("DELETE post")
+		db.Exec("DELETE posted")
+	}()
 
 	// Make sure we can ping to it
 	err = db.Ping()
@@ -22,30 +54,38 @@ func main() {
 	}
 
 	// Create some value
-	_, err = db.Exec("CREATE company SET name = 'SurrealDB', cofounders = [person:tobie, person:jaime]")
+	_, err = db.Exec("CREATE user:mark SET name = 'mark', age = 9999")
 	if err != nil {
 		panic(err)
 	}
 
-	// Read it back
-	rows, err := db.Query("SELECT cofounders, id, name FROM company")
-	if err != nil {
-		panic(err)
-	}
-	for rows.Next() {
-		var (
-			name       string
-			id         string
-			cofounders sql2.StringSlice
-		)
-
-		// Note: the columns are always sorted alphabetically, regardless of the order in your query
-		err := rows.Scan(&cofounders, &id, &name)
+	for i := 0; i < 20; i++ {
+		_, err = db.Exec(fmt.Sprintf("CREATE post:%v SET title = '%v', slug='%v'", i, i, i))
 		if err != nil {
 			panic(err)
 		}
 
-		fmt.Println("row", id, name, cofounders)
+		_, err = db.Exec(fmt.Sprintf("RELATE user:mark->posted->post:%v SET when=time::now()", i))
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Read it back
+	rows, err := db.Query("SELECT id, name, ->posted as posted, ->posted->post AS posts FROM user:mark fetch posts, posted")
+	if err != nil {
+		panic(err)
+	}
+	for rows.Next() {
+		resp := queryResp{}
+
+		// Note: the columns are always sorted alphabetically, regardless of the order in your query
+		err := rows.Scan(&resp.ID, &resp.Name, &resp.Posted, &resp.Posts)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println("row", resp)
 	}
 
 	// Cleanup

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/surrealdb/surrealdb.go
 
 go 1.18
 
-require github.com/gorilla/websocket v1.5.0
+require (
+	github.com/google/uuid v1.3.0
+	github.com/gorilla/websocket v1.5.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/surrealdb/surrealdb.go
+module github.com/emehrkay/surrealdb.go
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/surrealdb/surrealdb.go
 go 1.18
 
 require github.com/gorilla/websocket v1.5.0
-
-replace github.com/surrealdb/surrealdb.go => ./

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
-module github.com/emehrkay/surrealdb.go
+module github.com/surrealdb/surrealdb.go
 
 go 1.18
 
 require github.com/gorilla/websocket v1.5.0
+
+replace github.com/surrealdb/surrealdb.go => ./

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/sql/conn.go
+++ b/sql/conn.go
@@ -69,16 +69,13 @@ func (s *Conn) parseMethod(query string) (string, string, error) {
 	return strings.ToLower(query[:idx]), query[idx+1:], nil
 }
 
+func (s *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	actual := NamedValuesToValues(args)
+	return s.Execute(ctx, query, actual)
+}
+
 func (s *Conn) ExecerContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	named := map[string]any{}
-	for _, a := range args {
-		named[a.Name] = a.Value
-	}
-
-	actual := []driver.Value{
-		named,
-	}
-
+	actual := NamedValuesToValues(args)
 	rows, err := s.Execute(ctx, query, actual)
 	if err != nil {
 		return nil, err
@@ -90,15 +87,7 @@ func (s *Conn) ExecerContext(ctx context.Context, query string, args []driver.Na
 }
 
 func (s *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	named := map[string]any{}
-	for _, a := range args {
-		named[a.Name] = a.Value
-	}
-
-	actual := []driver.Value{
-		named,
-	}
-
+	actual := NamedValuesToValues(args)
 	rows, err := s.Execute(ctx, query, actual)
 	if err != nil {
 		return nil, err

--- a/sql/conn.go
+++ b/sql/conn.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"github.com/surrealdb/surrealdb.go"
 	"strings"
+
+	"github.com/surrealdb/surrealdb.go"
 )
 
 type Conn struct {

--- a/sql/conn.go
+++ b/sql/conn.go
@@ -110,11 +110,7 @@ func (s *Conn) ExecContext(ctx context.Context, query string, args []driver.Name
 }
 
 func (s *Conn) Execute(ctx context.Context, query string, args []driver.Value) (*Rows, error) {
-	// TODO: abstract prepping the query
-	// trim all leading and trailing whitespace
-	// remove new lines
-	query = newLineRegex.ReplaceAllString(query, " ")
-	query = tabRegex.ReplaceAllString(query, "")
+	query = PrepareQuery(query)
 	argInterfaces := make([]interface{}, len(args)+1)
 	argInterfaces[0] = strings.TrimSpace(query)
 

--- a/sql/conn.go
+++ b/sql/conn.go
@@ -19,6 +19,10 @@ func (s *Conn) Prepare(query string) (driver.Stmt, error) {
 	//	return nil, fmt.Errorf("invalid rawQuery: %w", err)
 	//}
 
+	return s.PrepareContext(context.Background(), query)
+}
+
+func (s *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
 	return &Stmt{
 		conn:     s,
 		rawQuery: query,
@@ -59,6 +63,95 @@ func (s *Conn) parseMethod(query string) (string, string, error) {
 
 	// TODO: do we validate this?
 	return strings.ToLower(query[:idx]), query[idx+1:], nil
+}
+
+func (s *Conn) ExecerContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	named := map[string]any{}
+	for _, a := range args {
+		named[a.Name] = a.Value
+	}
+
+	actual := []driver.Value{
+		named,
+	}
+
+	rows, err := s.Execute(ctx, query, actual)
+	if err != nil {
+		return nil, err
+	}
+
+	return Result{
+		AffectedRows: int64(len(rows.RawData)),
+	}, nil
+}
+
+func (s *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	named := map[string]any{}
+	for _, a := range args {
+		named[a.Name] = a.Value
+	}
+
+	actual := []driver.Value{
+		named,
+	}
+
+	rows, err := s.Execute(ctx, query, actual)
+	if err != nil {
+		return nil, err
+	}
+
+	return Result{
+		AffectedRows: int64(len(rows.RawData)),
+	}, nil
+}
+
+func (s *Conn) Execute(ctx context.Context, query string, args []driver.Value) (*Rows, error) {
+	argInterfaces := make([]interface{}, len(args)+1)
+	argInterfaces[0] = query
+
+	for idx, arg := range args {
+		argInterfaces[idx+1] = s.convertArgument(arg)
+	}
+
+	res, err := s.Send("query", argInterfaces...)
+	if err != nil {
+		return nil, fmt.Errorf("error during Exec: %w", err)
+	}
+
+	arr, ok := res.([]interface{})
+	if !ok || len(arr) != 1 {
+		// No idea what the result is
+		return nil, fmt.Errorf("unknown result")
+	}
+
+	lookup, ok := arr[0].(map[string]interface{})
+	if !ok {
+		// No idea what the result is
+		return nil, fmt.Errorf("unknown result, expected map")
+	}
+
+	status, _ := lookup["status"]
+	//duration, _ := lookup["time"]
+
+	switch status {
+	case "ERR":
+		detail, _ := lookup["detail"]
+		return nil, fmt.Errorf("query error: %s", detail)
+	case "OK":
+		result, _ := lookup["result"]
+		rows, ok := result.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unknown result value")
+		}
+
+		return &Rows{RawData: rows}, nil
+	default:
+		return nil, fmt.Errorf("unknown response status: %s", status)
+	}
+}
+
+func (s *Conn) convertArgument(val driver.Value) interface{} {
+	return val
 }
 
 // TODO: Potentially implement: ExecerContext, QueryerContext, ConnPrepareContext, and ConnBeginTx.

--- a/sql/rows.go
+++ b/sql/rows.go
@@ -16,12 +16,12 @@ type Rows struct {
 
 func (r *Rows) Columns() []string {
 	if r.nextInLine >= len(r.RawData) {
-		return []string{}
+		return r.detectedColumns
 	}
 
 	lookup, ok := r.RawData[r.nextInLine].(map[string]interface{})
 	if !ok {
-		return []string{} // This should never happen, but we cannot return an err...
+		return r.detectedColumns // This should never happen, but we cannot return an err...
 	}
 
 	r.detectedColumns = make([]string, 0, len(lookup))
@@ -45,6 +45,8 @@ func (r *Rows) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 
+	// TODO: hopefully we can property identify column types
+	// when we do, properly cast values here
 	lookup, ok := r.RawData[r.nextInLine].(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("unknown format of row")

--- a/sql/scanner.go
+++ b/sql/scanner.go
@@ -176,6 +176,15 @@ func (s *SurrealUUID) Scan(value any) error {
 	return err
 }
 
+func (s SurrealUUID) MarshalText() (text []byte, err error) {
+	return (s.UUID()).MarshalText()
+}
+
+func (s *SurrealUUID) UnmarshalText(data []byte) error {
+	sUID := s.UUID()
+	return sUID.UnmarshalText(data)
+}
+
 func (s *SurrealUUID) Value() (driver.Value, error) {
 	return json.Marshal(s)
 }

--- a/sql/scanner.go
+++ b/sql/scanner.go
@@ -1,6 +1,9 @@
 package sql
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type StringSlice struct {
 	Data []string
@@ -118,4 +121,20 @@ func (s *FloatSlice) Scan(src any) error {
 	}
 
 	return nil
+}
+
+type Many[T any] []T
+
+func (my *Many[T]) Scan(value any) error {
+	if value == nil {
+		*my = Many[T]{}
+		return nil
+	}
+
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(bytes, my)
 }

--- a/sql/stmt.go
+++ b/sql/stmt.go
@@ -35,7 +35,7 @@ func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
 	data := make([]driver.Value, len(cols))
 
 	driverResult := Result{}
-	for err := rows.Next(data); err != nil; err = rows.Next(data) {
+	if err := rows.Next(data); err != nil {
 		driverResult.AffectedRows++
 	}
 	return driverResult, nil

--- a/sql/types.go
+++ b/sql/types.go
@@ -1,0 +1,11 @@
+package sql
+
+type BaseEntity struct {
+	ID string `json:"id"`
+}
+
+type BaseRelationship struct {
+	BaseEntity
+	In  string `json:"in"`
+	Out string `json:"out"`
+}

--- a/sql/utils.go
+++ b/sql/utils.go
@@ -1,0 +1,50 @@
+package sql
+
+import (
+	"database/sql"
+	"reflect"
+	"strings"
+)
+
+var DefaultTagName = "json"
+
+// StructToNamedArgs will take a struct and pull all of its "json" (DefaultTagName)
+// while ignoring the excludes
+func StructToNamedArgs(entity any, excludes ...string) []sql.NamedArg {
+	return StructToNamedArgsTagName(entity, DefaultTagName, excludes...)
+}
+
+func StructToNamedArgsTagName(entity any, tagname string, excludes ...string) []sql.NamedArg {
+	args := []sql.NamedArg{}
+	entityType := reflect.TypeOf(entity)
+
+	// resolve the entity type and name
+	for entityType.Kind() == reflect.Ptr {
+		entityType = entityType.Elem()
+	}
+
+	val := reflect.ValueOf(entity)
+	for i := 0; i < val.NumField(); i++ {
+		field := entityType.Field(i)
+		tag, ok := field.Tag.Lookup(tagname)
+		if !ok || strings.TrimSpace(tag) == "" || SliceContains(excludes, tag) {
+			continue
+		}
+
+		fieldValue := val.Field(i)
+		args = append(args, sql.Named(tag, fieldValue.Interface()))
+	}
+
+	return args
+}
+
+// SliceContains utilty func that will check to see if a slice has an element
+func SliceContains[T comparable](arr []T, element T) bool {
+	for _, ele := range arr {
+		if ele == element {
+			return true
+		}
+	}
+
+	return false
+}

--- a/sql/utils.go
+++ b/sql/utils.go
@@ -4,10 +4,12 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"reflect"
+	"regexp"
 	"strings"
 )
 
 var DefaultTagName = "json"
+var tagRE = regexp.MustCompile("[^a-zA-Z0-9-_]+")
 
 // StructToNamedArgs will take a struct and pull all of its "json" (DefaultTagName)
 // while ignoring the excludes
@@ -27,7 +29,13 @@ func StructToNamedArgsTagName(entity any, tagname string, excludes ...string) []
 	val := reflect.ValueOf(entity)
 	for i := 0; i < val.NumField(); i++ {
 		field := entityType.Field(i)
-		tag, ok := field.Tag.Lookup(tagname)
+		tagValue, ok := field.Tag.Lookup(tagname)
+		parts := tagRE.Split(tagValue, -1)
+		if len(parts) < 1 {
+			continue
+		}
+
+		tag := parts[0]
 		if !ok || strings.TrimSpace(tag) == "" || SliceContains(excludes, tag) {
 			continue
 		}

--- a/sql/utils.go
+++ b/sql/utils.go
@@ -48,3 +48,16 @@ func SliceContains[T comparable](arr []T, element T) bool {
 
 	return false
 }
+
+// PrepareQuery allows for queries to be multiple lines by stripping whitespace and
+// replacing newlines with a whitespace
+func PrepareQuery(query string) string {
+	parts := strings.Split(strings.ReplaceAll(query, "\r\n", "\n"), "\n")
+	final := make([]string, len(parts))
+
+	for _, part := range parts {
+		final = append(final, strings.TrimSpace(part))
+	}
+
+	return strings.Join(final, " ")
+}

--- a/sql/utils.go
+++ b/sql/utils.go
@@ -10,12 +10,12 @@ var DefaultTagName = "json"
 
 // StructToNamedArgs will take a struct and pull all of its "json" (DefaultTagName)
 // while ignoring the excludes
-func StructToNamedArgs(entity any, excludes ...string) []sql.NamedArg {
+func StructToNamedArgs(entity any, excludes ...string) []any {
 	return StructToNamedArgsTagName(entity, DefaultTagName, excludes...)
 }
 
-func StructToNamedArgsTagName(entity any, tagname string, excludes ...string) []sql.NamedArg {
-	args := []sql.NamedArg{}
+func StructToNamedArgsTagName(entity any, tagname string, excludes ...string) []any {
+	args := []any{}
 	entityType := reflect.TypeOf(entity)
 
 	// resolve the entity type and name

--- a/sql/utils.go
+++ b/sql/utils.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"reflect"
 	"strings"
 )
@@ -60,4 +61,15 @@ func PrepareQuery(query string) string {
 	}
 
 	return strings.Join(final, " ")
+}
+
+func NamedValuesToValues(namedValues []driver.NamedValue) []driver.Value {
+	named := map[string]any{}
+	for _, n := range namedValues {
+		named[n.Name] = n.Value
+	}
+
+	return []driver.Value{
+		named,
+	}
 }


### PR DESCRIPTION
I added a few useful things:

- Added sql/scanner/Many type as a generic which will support path collections (it should probably support any type)
- Added sql/types.go to define a base Entity and Relationship type that can be embedded into other types and should save some some redundant definitions
- Fixed the json marshal call to disable encode html so that (->) characters are sent to the db (maybe the db itself should support html encoded chars)
- Updated the example/main.go to show all of this in action